### PR TITLE
Add bower support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "chat-grad-project",
+  "version": "1.0.0",
+  "homepage": "https://github.com/joebandenburg/chat-grad-project",
+  "authors": [
+    "Joe Bandenburg <joe@bandenburg.com>"
+  ],
+  "main": "server.js",
+  "moduleType": [
+    "globals"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test"
+  ],
+  "dependencies": {}
+}

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+test:
+  pre:
+    - bower install
 deployment:
   prod:
     branch: master

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "URIjs": "^1.15.1",
+    "bower": "^1.4.1",
     "cookie-parser": "^1.3.5",
     "express": "^4.13.0",
     "mongodb": "^2.0.35",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "postinstall": "bower install"
   },
   "repository": {
     "type": "git",

--- a/server/server.js
+++ b/server/server.js
@@ -6,6 +6,7 @@ var URI = require("URIjs");
 module.exports = function(port, db, oauthClientId, oauthSecret) {
     var app = express();
 
+    app.use("/bower_components", express.static("bower_components"));
     app.use(express.static("public"));
     app.use(cookieParser());
 


### PR DESCRIPTION
Currently, bower can not be used:
- Server does not serve up files from "bower-components" directory
- CircleCI does not perform a `bower install` before running tests
- Heroku does not perform a `bower install` so that the files are able to be served

This pull request is to address these issues.
